### PR TITLE
Remove prometheus default filter on cluster name

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,2 +1,1 @@
 ---
-metrix::version: "%{alias('metrix::install::version')}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,4 @@
 class metrix (
-  String $version,
   String $root_api_token,
   String $password,
   String $prometheus_ip,
@@ -20,7 +19,6 @@ class metrix (
     show_diff => false,
     content   => epp('metrix/99-local.py',
       {
-        'version'         => $version,
         'password'        => $password,
         'slurm_password'  => $slurm_password,
         'cluster_name'    => $cluster_name,

--- a/templates/99-local.py.epp
+++ b/templates/99-local.py.epp
@@ -69,13 +69,9 @@ ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_ALLOW)
 PROMETHEUS = {
     'url': 'http://<%= $prometheus_ip %>:<%= $prometheus_port %>',
     'headers': {},
-<% if versioncmp($version, '1.3.1') >= 0 { -%>
     'filter': {
-        "default": "cluster='<%= $cluster_name %>'"
+        'default': ''
     }
-<% } else { -%>
-    'filter': "",
-<% } -%>
 }
 
 STATIC_URL = '/static/'


### PR DESCRIPTION
The cluster label is currently missing from puppet-magic_castle config so the current filter prevents data querying.